### PR TITLE
NTGR-541: Update plugin license type to GPL v2 or later

### DIFF
--- a/accredible-learndash-add-on.php
+++ b/accredible-learndash-add-on.php
@@ -10,7 +10,7 @@
  * Version:     1.0.0
  * Author:      Accredible
  * Author URI:  https://www.accredible.com/
- * License:     GPL v2
+ * License:     GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
 


### PR DESCRIPTION
This PR updates the plugin license type to include later versions of GPL following the recommendation from WordPress.

> Although any GPL-compatible license is acceptable, using the same license as WordPress — “GPLv2 or later” — is strongly recommended.

[Detailed Plugin Guidelines | Plugin Developer Handbook | WordPress Developer Resources](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#1-plugins-must-be-compatible-with-the-gnu-general-public-license) 