### PR TITLE
NTGR-592: Increase max file post size

### DIFF
--- a/custom.ini
+++ b/custom.ini
@@ -1,2 +1,4 @@
 # Increase upload_max_filesize to install the LearnDash plugin
-upload_max_filesize=512M
+upload_max_filesize=128M
+post_max_size=128M
+max_execution_time=300


### PR DESCRIPTION
This PR increases the max size of post data allowed in the WordPress docker container in order for plugin installation whose file size is larger than 8MB.

If you've already set up the WordPress container, you need to re-run the build commands to apply this change:

#### Re-build WordPress

```
docker-compose up -d --no-deps --build wordpress 
```

#### Re-set up PHPUnit & PHP CodeSniffer

Log into the WordPress container and go to the plugin directory.

```
docker exec -it accredible-learndash-add-on_wordpress_1 bash
cd $PLUGIN_DIR
```

Run the following setup commands:

```
bash bin/init-wp-dev.sh
composer install
```
