### PR TITLE
NTGR-608: Sanitize all request inputs

### DIFF
--- a/includes/class-accredible-learndash-admin-action-handler.php
+++ b/includes/class-accredible-learndash-admin-action-handler.php
@@ -22,7 +22,7 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Action_Handler' ) ) :
 		public static function add_auto_issuance( $data ) {
 			self::verify_nonce( $data['nonce'], 'add_auto_issuance' );
 
-			$result = Accredible_Learndash_Model_Auto_Issuance::insert( self::auto_issuance_params( $data['accredible_learndash_object'] ) );
+			$result = Accredible_Learndash_Model_Auto_Issuance::insert( $data['accredible_learndash_object'] );
 
 			if ( false === $result ) {
 				wp_die( 'Failed to create.' );
@@ -40,8 +40,7 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Action_Handler' ) ) :
 		public static function edit_auto_issuance( $data ) {
 			self::verify_nonce( $data['nonce'], 'edit_auto_issuance' . $data['id'] );
 
-			$auto_issuance_params = self::auto_issuance_params( $data['accredible_learndash_object'] );
-
+			$auto_issuance_params = $data['accredible_learndash_object'];
 			foreach ( $auto_issuance_params as $key => $value ) {
 				if ( is_null( $auto_issuance_params[ $key ] ) || empty( $auto_issuance_params[ $key ] ) ) {
 					wp_die( 'Failed to update.' );
@@ -69,24 +68,6 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Action_Handler' ) ) :
 			} else {
 				self::redirect_to( $data['redirect_url'] );
 			}
-		}
-
-		/**
-		 * Return permitted parameters for auto issuance
-		 *
-		 * @param array $data Data to add/modify an auto issuance.
-		 */
-		private static function auto_issuance_params( $data ) {
-			$permitted_params     = array( 'kind', 'post_id', 'accredible_group_id' );
-			$auto_issuance_params = array();
-
-			foreach ( $permitted_params as $param ) {
-				if ( array_key_exists( $param, $data ) ) {
-					$auto_issuance_params[ $param ] = $data[ $param ];
-				}
-			}
-
-			return $auto_issuance_params;
 		}
 
 		/**

--- a/includes/class-accredible-learndash-admin-menu.php
+++ b/includes/class-accredible-learndash-admin-menu.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Menu' ) ) :
 				'Admin Action',
 				'administrator',
 				'accredible_learndash_admin_action',
-				array( 'Accredible_Learndash_Admin_Menu', 'admin_action' )
+				array( 'Accredible_Learndash_Admin_Action_Handler', 'call' )
 			);
 		}
 
@@ -106,26 +106,6 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Menu' ) ) :
 		}
 
 		/**
-		 * Render admin action page
-		 */
-		public static function admin_action() {
-			$action        = self::sanitize_parameter( 'action' );
-			$class_methods = get_class_methods( 'Accredible_Learndash_Admin_Action_Handler' );
-			if ( in_array( $action, $class_methods, true ) ) {
-				$data = array(
-					'id'                          => self::sanitize_parameter( 'id' ),
-					'nonce'                       => self::sanitize_parameter( '_mynonce' ),
-					'page_num'                    => self::sanitize_parameter( 'page_num' ),
-					'accredible_learndash_object' => self::sanitize_object( $action ),
-					'redirect_url'                => isset( $_REQUEST['redirect_url'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_url'] ) ) : wp_get_referer(), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				);
-				Accredible_Learndash_Admin_Action_Handler::$action( $data );
-			} else {
-				wp_die( 'An action type mismatch has been detected.' );
-			}
-		}
-
-		/**
 		 * Add plugin action links.
 		 *
 		 * @param Array $links An array of plugin links.
@@ -134,51 +114,7 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Menu' ) ) :
 			$mylinks = array(
 				'<a href="' . admin_url( 'admin.php?page=accredible_learndash_settings' ) . '">Settings</a>',
 			);
-			return array_merge( $links, $mylinks );
-		}
-
-		/**
-		 * Sanitize a string parameter.
-		 *
-		 * @param string $key The key of the parameter.
-		 */
-		private static function sanitize_parameter( $key ) {
-			return isset( $_REQUEST[ $key ] ) ? sanitize_key( wp_unslash( $_REQUEST[ $key ] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-
-		/**
-		 * Sanitize accredible learndash object.
-		 *
-		 * @param string $action The name of the action.
-		 */
-		private static function sanitize_object( $action ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! isset( $_REQUEST['accredible_learndash_object'] ) ) {
-				return array();
-			}
-
-			switch ( $action ) {
-				case 'add_auto_issuance':
-				case 'edit_auto_issuance':
-					$object = array(
-						'kind'                => self::sanitize_object_field( 'kind' ),
-						'post_id'             => self::sanitize_object_field( 'post_id' ),
-						'accredible_group_id' => self::sanitize_object_field( 'accredible_group_id' ),
-					);
-					break;
-				default:
-					$object = array();
-			}
-			return $object;
-		}
-
-		/**
-		 * Sanitize accredible learndash object field.
-		 *
-		 * @param string $field The name of the field.
-		 */
-		private static function sanitize_object_field( $field ) {
-			return isset( $_REQUEST['accredible_learndash_object'][ $field ] ) ? sanitize_text_field( wp_unslash( $_REQUEST['accredible_learndash_object'][ $field ] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return array_merge( $mylinks, $links );
 		}
 	}
 endif;

--- a/includes/models/class-accredible-learndash-model.php
+++ b/includes/models/class-accredible-learndash-model.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Accredible_Learndash_Model' ) ) :
 				$sql .= " OFFSET $offset";
 			}
 			// XXX `$where_sql` is a raw SQL so `$wpdb->prepare` cannot be used.
-			return $wpdb->get_results( $sql ); // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			return $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		/**
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Accredible_Learndash_Model' ) ) :
 				$sql .= " WHERE $where_sql";
 			}
 			// XXX `$where_sql` is a raw SQL so `$wpdb->prepare` cannot be used.
-			return $wpdb->get_var( $sql ); // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			return $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		/**

--- a/includes/templates/admin-auto-issuance-form.php
+++ b/includes/templates/admin-auto-issuance-form.php
@@ -12,8 +12,8 @@ require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-a
 
 $accredible_learndash_courses = Accredible_Learndash_Model_Auto_Issuance::get_course_options();
 
-$accredible_learndash_issuance_current_page = isset( $_GET['page_num'] ) ? esc_attr( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-$accredible_learndash_issuance_id           = isset( $_GET['id'] ) ? esc_attr( wp_unslash( $_GET['id'] ) ) : null; // phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_issuance_current_page = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_issuance_id           = isset( $_GET['id'] ) ? sanitize_key( wp_unslash( $_GET['id'] ) ) : null; // phpcs:disable WordPress.Security.NonceVerification.Recommended
 
 $accredible_learndash_group       = array();
 $accredible_learndash_form_action = 'add_auto_issuance';
@@ -26,7 +26,7 @@ $accredible_learndash_issuance    = (object) array(
 if ( ! is_null( $accredible_learndash_issuance_id ) ) {
 	$accredible_learndash_form_action = 'edit_auto_issuance';
 
-	$accredible_learndash_issuance_nonce = isset( $_GET['_mynonce'] ) ? esc_attr( wp_unslash( $_GET['_mynonce'] ) ) : null;
+	$accredible_learndash_issuance_nonce = isset( $_GET['_mynonce'] ) ? sanitize_key( wp_unslash( $_GET['_mynonce'] ) ) : null;
 
 	if ( ! ( isset( $accredible_learndash_issuance_nonce ) && wp_verify_nonce( $accredible_learndash_issuance_nonce, $accredible_learndash_form_action . $accredible_learndash_issuance_id ) ) ) {
 		wp_die( 'Invalid nonce.' );

--- a/includes/templates/admin-auto-issuance-form.php
+++ b/includes/templates/admin-auto-issuance-form.php
@@ -12,8 +12,8 @@ require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-a
 
 $accredible_learndash_courses = Accredible_Learndash_Model_Auto_Issuance::get_course_options();
 
-$accredible_learndash_issuance_current_page = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.NonceVerification.Recommended
-$accredible_learndash_issuance_id           = isset( $_GET['id'] ) ? sanitize_key( wp_unslash( $_GET['id'] ) ) : null; // phpcs:disable WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_issuance_current_page = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_issuance_id           = isset( $_GET['id'] ) ? sanitize_key( wp_unslash( $_GET['id'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 $accredible_learndash_group       = array();
 $accredible_learndash_form_action = 'add_auto_issuance';

--- a/includes/templates/admin-auto-issuance-logs.php
+++ b/includes/templates/admin-auto-issuance-logs.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || die;
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-table-helper.php';
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance-log.php';
 
-$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $accredible_learndash_page_size     = 20;
 $accredible_learndash_table_columns = array(
 	'recipient_name',

--- a/includes/templates/admin-auto-issuance-logs.php
+++ b/includes/templates/admin-auto-issuance-logs.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || die;
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-table-helper.php';
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance-log.php';
 
-$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? esc_attr( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.NonceVerification.Recommended
 $accredible_learndash_page_size     = 20;
 $accredible_learndash_table_columns = array(
 	'recipient_name',

--- a/includes/templates/admin-issuance-list.php
+++ b/includes/templates/admin-issuance-list.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || die;
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-table-helper.php';
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance.php';
 
-$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? esc_attr( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.NonceVerification.Recommended
 $accredible_learndash_page_size     = 20;
 $accredible_learndash_table_columns = array( 'post_id', 'accredible_group_id', 'kind', 'created_at' );
 $accredible_learndash_row_actions   = array(

--- a/includes/templates/admin-issuance-list.php
+++ b/includes/templates/admin-issuance-list.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || die;
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-table-helper.php';
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance.php';
 
-$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:disable WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $accredible_learndash_page_size     = 20;
 $accredible_learndash_table_columns = array( 'post_id', 'accredible_group_id', 'kind', 'created_at' );
 $accredible_learndash_row_actions   = array(

--- a/tests/includes/test-class-accredible-learndash-admin-menu.php
+++ b/tests/includes/test-class-accredible-learndash-admin-menu.php
@@ -48,8 +48,8 @@ class Accredible_Learndash_Admin_Menu_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array(
-				"<a href='https://example.com'>Link 1</a>",
 				'<a href="' . admin_url( 'admin.php?page=accredible_learndash_settings' ) . '">Settings</a>',
+				"<a href='https://example.com'>Link 1</a>",
 			),
 			$result
 		);

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -29,7 +29,7 @@ class Accredible_Learndash_Uninstall_Test extends WP_UnitTestCase {
 		// XXX Stop transforming all `DROP TABLE` to `DROP TEMPORARY TABLE`.
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 		// Run the uninstall script.
-		define( 'WP_UNINSTALL_PLUGIN', true ); // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		define( 'WP_UNINSTALL_PLUGIN', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		include plugin_dir_path( __DIR__ ) . '/uninstall.php';
 
 		// Plugin options to be empty.


### PR DESCRIPTION
This PR adds sanitization to all request inputs removing all `phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized` from the code.