### PR TITLE
NTGR-611 | Use composer v1 for older PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
-        wordpress: ['5.9']
+        include:
+          - php: '5.6'
+            composer: 1
+            wordpress: '5.9'
+          - php: '7.0'
+            composer: 1
+            wordpress: '5.9'
+          - php: '7.1'
+            composer: 1
+            wordpress: '5.9'
+          - php: '7.2'
+            composer: 2
+            wordpress: '5.9'
+          - php: '7.3'
+            composer: 2
+            wordpress: '5.9'
+          - php: '7.4'
+            composer: 2
+            wordpress: '5.9'
 
     name: WP version ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
 
@@ -44,21 +61,11 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: upload_max_filesize=512M
 
-      - name: Select Composer Version
-        run: |
-          if (( ${{ matrix.php }} <= 7.1 ))
-          then
-            echo "COMPOSER_VERSION=1" >> $GITHUB_ENV
-          else
-            echo "COMPOSER_VERSION=2" >> $GITHUB_ENV
-          fi
-
-      - name: Build Composer Version ${{ env.COMPOSER_VERSION }}
-        if:
+      - name: Build Composer Version ${{ matrix.composer }}
         uses: php-actions/composer@v6
         with:
           php_version: ${{ matrix.php }}
-          version: COMPOSER_VERSION
+          version: ${{ matrix.composer }}
           command: update
 
       - name: Initialise WP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,20 +44,21 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: upload_max_filesize=512M
 
-      - name: Build Composer Version 1
-        if: ${{ matrix.php <= 7.1 }}
-        uses: php-actions/composer@v6
-        with:
-          php_version: ${{ matrix.php }}
-          version: 1
-          command: update
+      - name: Select Composer Version
+        run: |
+          if (( ${{ matrix.php }} <= 7.1 ))
+          then
+            echo "COMPOSER_VERSION=1" >> $GITHUB_ENV
+          else
+            echo "COMPOSER_VERSION=2" >> $GITHUB_ENV
+          fi
 
-      - name: Build Composer Version 2
-        if: ${{ matrix.php >= 7.2 }}
+      - name: Build Composer Version ${{ env.COMPOSER_VERSION }}
+        if:
         uses: php-actions/composer@v6
         with:
           php_version: ${{ matrix.php }}
-          version: 2
+          version: COMPOSER_VERSION
           command: update
 
       - name: Initialise WP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,19 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: upload_max_filesize=512M
 
-      - name: Build Composer
+      - name: Build Composer Version 1
+        if: ${{ matrix.php <= 7.1 }}
         uses: php-actions/composer@v6
         with:
           php_version: ${{ matrix.php }}
-          command: update
+          version: 1
+
+      - name: Build Composer Version 2
+        if: ${{ matrix.php >= 7.2 }}
+        uses: php-actions/composer@v6
+        with:
+          php_version: ${{ matrix.php }}
+          version: 2
 
       - name: Initialise WP
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           php_version: ${{ matrix.php }}
           version: 1
+          command: update
 
       - name: Build Composer Version 2
         if: ${{ matrix.php >= 7.2 }}
@@ -57,6 +58,7 @@ jobs:
         with:
           php_version: ${{ matrix.php }}
           version: 2
+          command: update
 
       - name: Initialise WP
         env:


### PR DESCRIPTION
Version 2.3.0 of Composer was released recently, which is why two builds on identical Code versions had inconsistent results.

https://blog.packagist.com/composer-2-3/

I have added conditional logic to build version 1 of composer for older PHP versions.