### PR TITLE
NTGR-618: Add svnignore

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -1,0 +1,13 @@
+.github
+bin
+tests
+vendor
+
+*.xml.dist
+.gitignore
+.svnignore
+composer.*
+custom.ini
+Dockerfile
+docker-compose.yml
+README.md


### PR DESCRIPTION
This PR adds `.svnignore` to exclude unnecessary dirs and files when uploading the plugin to SVN.