### PR TITLE
add get_row method to models and remove nonce verification for edit form

### DIFF
--- a/includes/helpers/class-accredible-learndash-admin-table-helper.php
+++ b/includes/helpers/class-accredible-learndash-admin-table-helper.php
@@ -331,6 +331,7 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Table_Helper' ) ) :
 					if ( ( ! empty( $value['label'] ) ) && ( ! empty( $value['action'] ) ) ) {
 						$page               = '';
 						$has_confirm_dialog = false;
+						$need_nonce_url     = false;
 						switch ( $value['action'] ) {
 							case 'edit_auto_issuance':
 								$page = 'accredible_learndash_auto_issuance';
@@ -338,20 +339,25 @@ if ( ! class_exists( 'Accredible_Learndash_Admin_Table_Helper' ) ) :
 							case 'delete_auto_issuance':
 								$page               = 'accredible_learndash_admin_action';
 								$has_confirm_dialog = true;
+								$need_nonce_url     = true;
 								break;
 							default:
 								$page = 'accredible_learndash_issuance_list';
 						}
 
-						$nonce_url = wp_nonce_url(
-							admin_url( 'admin.php?page=' . $page . '&action=' . $value['action'] . '&page_num=' . self::$current_page . '&id=' . $id ),
-							$value['action'] . $id,
-							'_mynonce'
-						);
+						$url = admin_url( 'admin.php?page=' . $page . '&action=' . $value['action'] . '&page_num=' . self::$current_page . '&id=' . $id );
+
+						if ( $need_nonce_url ) {
+							$url = wp_nonce_url(
+								$url,
+								$value['action'] . $id,
+								'_mynonce'
+							);
+						}
 
 						$actions .= sprintf(
 							'<a href="%1s" %2s class="button accredible-button-outline-natural accredible-button-small">' . $value['label'] . '</a>',
-							$nonce_url,
+							$url,
 							$has_confirm_dialog ? 'data-accredible-dialog="true"' : ''
 						);
 					}

--- a/includes/models/class-accredible-learndash-model.php
+++ b/includes/models/class-accredible-learndash-model.php
@@ -38,6 +38,22 @@ if ( ! class_exists( 'Accredible_Learndash_Model' ) ) :
 		}
 
 		/**
+		 * Return a DB record.
+		 *
+		 * @param string $where_sql SQL where clause.
+		 */
+		public static function get_row( $where_sql = '' ) {
+			global $wpdb;
+			$sql = 'SELECT * FROM ' . static::table_name();
+			if ( ! empty( $where_sql ) ) {
+				$sql .= " WHERE $where_sql";
+			}
+
+			// XXX `$where_sql` is a raw SQL so `$wpdb->prepare` cannot be used.
+			return $wpdb->get_row( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		/**
 		 * Return the total count of the records.
 		 *
 		 * @param string $where_sql SQL where clause.

--- a/includes/templates/admin-auto-issuance-form.php
+++ b/includes/templates/admin-auto-issuance-form.php
@@ -26,13 +26,13 @@ $accredible_learndash_issuance    = (object) array(
 if ( ! is_null( $accredible_learndash_issuance_id ) ) {
 	$accredible_learndash_form_action = 'edit_auto_issuance';
 
-	$accredible_learndash_issuance_nonce = isset( $_GET['_mynonce'] ) ? sanitize_key( wp_unslash( $_GET['_mynonce'] ) ) : null;
+	$accredible_learndash_issuance_nonce = isset( $_GET['_mynonce'] ) ? sanitize_key( wp_unslash( $_GET['_mynonce'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-	if ( ! ( isset( $accredible_learndash_issuance_nonce ) && wp_verify_nonce( $accredible_learndash_issuance_nonce, $accredible_learndash_form_action . $accredible_learndash_issuance_id ) ) ) {
-		wp_die( 'Invalid nonce.' );
+	$accredible_learndash_issuance = Accredible_Learndash_Model_Auto_Issuance::get_row( "id = $accredible_learndash_issuance_id" );
+
+	if ( ! ( isset( $accredible_learndash_issuance ) ) ) {
+		wp_die( 'Auto Issuance not found.' );
 	}
-
-	$accredible_learndash_issuance = Accredible_Learndash_Model_Auto_Issuance::get_results( "id = $accredible_learndash_issuance_id" )[0];
 
 	// Fetch saved group by id to fill autocomplete.
 	if ( ! is_null( $accredible_learndash_issuance ) && ! empty( $accredible_learndash_issuance->accredible_group_id ) ) {

--- a/tests/includes/models/test-class-accredible-learndash-model-auto-issuance-log.php
+++ b/tests/includes/models/test-class-accredible-learndash-model-auto-issuance-log.php
@@ -68,6 +68,50 @@ class Accredible_Learndash_Model_Auto_Issuance_Log_Test extends Accredible_Learn
 	}
 
 	/**
+	 * Test if it returns an auto issuance log with a WHERE clause.
+	 */
+	public function test_get_row() {
+		$result = Accredible_Learndash_Model_Auto_Issuance_Log::get_row();
+		$this->assertEquals( null, $result );
+
+		global $wpdb;
+		$data1 = array(
+			'accredible_learndash_auto_issuance_id' => 1,
+			'user_id'                               => 1,
+			'accredible_group_id'                   => 1,
+			'accredible_group_name'                 => 'My Course 1',
+			'recipient_name'                        => 'Tom Test',
+			'recipient_email'                       => 'tom@example.com',
+			'credential_url'                        => 'https://www.credential.net/10000000',
+			'created_at'                            => time(),
+		);
+		$data2 = array(
+			'accredible_learndash_auto_issuance_id' => 2,
+			'user_id'                               => 2,
+			'accredible_group_id'                   => 2,
+			'recipient_name'                        => 'Jerry Test',
+			'recipient_email'                       => 'jerry@example.com',
+			'error_message'                         => 'The server could not respond. Your API key might be invalid.',
+			'created_at'                            => time(),
+		);
+		$wpdb->insert( $wpdb->prefix . 'accredible_learndash_auto_issuance_logs', $data1 );
+		$data1_id = $wpdb->insert_id;
+		$wpdb->insert( $wpdb->prefix . 'accredible_learndash_auto_issuance_logs', $data2 );
+		$data2_id = $wpdb->insert_id;
+
+		$result = Accredible_Learndash_Model_Auto_Issuance_Log::get_row();
+		$this->assertEquals( $data1_id, $result->id );
+
+		// With $where_sql.
+		$result = Accredible_Learndash_Model_Auto_Issuance_Log::get_row( "user_id = 2 AND recipient_name = 'Jerry Test'" );
+		$this->assertEquals( $data2_id, $result->id );
+
+		// With no results.
+		$result = Accredible_Learndash_Model_Auto_Issuance_Log::get_row( 'user_id = 3' );
+		$this->assertEquals( null, $result );
+	}
+
+	/**
 	 * Test if it returns the total number of found records.
 	 */
 	public function test_get_total_count() {

--- a/tests/includes/models/test-class-accredible-learndash-model-auto-issuance.php
+++ b/tests/includes/models/test-class-accredible-learndash-model-auto-issuance.php
@@ -61,6 +61,43 @@ class Accredible_Learndash_Model_Auto_Issuance_Test extends Accredible_Learndash
 	}
 
 	/**
+	 * Test if it returns an auto issuance with a WHERE clause.
+	 */
+	public function test_get_row() {
+		$result = Accredible_Learndash_Model_Auto_Issuance::get_row();
+		$this->assertEquals( null, $result );
+
+		global $wpdb;
+		$data1 = array(
+			'kind'                => 'course_completed',
+			'post_id'             => 1,
+			'accredible_group_id' => 1,
+			'created_at'          => time(),
+		);
+		$data2 = array(
+			'kind'                => 'course_completed',
+			'post_id'             => 2,
+			'accredible_group_id' => 2,
+			'created_at'          => time(),
+		);
+		$wpdb->insert( $wpdb->prefix . 'accredible_learndash_auto_issuances', $data1 );
+		$data1_id = $wpdb->insert_id;
+		$wpdb->insert( $wpdb->prefix . 'accredible_learndash_auto_issuances', $data2 );
+		$data2_id = $wpdb->insert_id;
+
+		$result = Accredible_Learndash_Model_Auto_Issuance::get_row();
+		$this->assertEquals( $data1_id, $result->id );
+
+		// With $where_sql.
+		$result = Accredible_Learndash_Model_Auto_Issuance::get_row( 'post_id = 2' );
+		$this->assertEquals( $data2_id, $result->id );
+
+		// With no results.
+		$result = Accredible_Learndash_Model_Auto_Issuance::get_row( 'post_id = 10' );
+		$this->assertEquals( null, $result );
+	}
+
+	/**
 	 * Test if it returns the total number of found records.
 	 */
 	public function test_get_total_count() {


### PR DESCRIPTION
Source: [NTGR-602](https://accredible.atlassian.net/browse/NTGR-602)

This PR adds a function called `get_row` to the
model to fetch a single record.

This also remove the `nonce` verification for the
auto issuance edit form and return an error if
object is not found.