### PR TITLE
NTGR-645 - fetch auto issuances with Ajax

### DIFF
--- a/assets/css/accredible-admin-settings.css
+++ b/assets/css/accredible-admin-settings.css
@@ -293,7 +293,6 @@ button[class*="accredible-button"] {
 
 #accredible-issuer-info {
     min-height: 60px;
-    padding: var(--accredible-spacing-3x) 0;
 }
 
 .accredible-content .status-tile .logo {

--- a/assets/css/accredible-admin-settings.css
+++ b/assets/css/accredible-admin-settings.css
@@ -293,7 +293,7 @@ button[class*="accredible-button"] {
 
 #accredible-issuer-info {
     min-height: 60px;
-    padding: 0 var(--accredible-spacing-3x);
+    padding: var(--accredible-spacing-3x) 0;
 }
 
 .accredible-content .status-tile .logo {

--- a/assets/js/accredible-common.js
+++ b/assets/js/accredible-common.js
@@ -26,4 +26,12 @@ jQuery(function(){
            }
         });
     };
+
+    accredibleAjax.loadAutoIssuanceListInfo = function() {
+        var post_data = {
+            'action': 'accredible_learndash_ajax_load_auto_issuance_list_html'
+        };
+        // post_data = Object.assign(post_data, formData);
+        return jQuery.post(accredibledata.ajaxurl, post_data).then();
+    }
 });

--- a/assets/js/accredible-common.js
+++ b/assets/js/accredible-common.js
@@ -31,7 +31,6 @@ jQuery(function(){
         var post_data = {
             'action': 'accredible_learndash_ajax_load_auto_issuance_list_html'
         };
-        // post_data = Object.assign(post_data, formData);
         return jQuery.post(accredibledata.ajaxurl, post_data).then();
     }
 });

--- a/includes/ajax/class-accredible-learndash-ajax.php
+++ b/includes/ajax/class-accredible-learndash-ajax.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || die;
 
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-issuer-helper.php';
+require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-auto-issuance-list-helper.php';
 require_once plugin_dir_path( __DIR__ ) . 'class-accredible-learndash-admin-action-handler.php';
 
 if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
@@ -69,6 +70,26 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 		}
 
 		/**
+		 * load auto issuances
+		 */
+		public static function load_auto_issuances() {
+			$current_page = self::get_request_value( 'page_num', 1 );
+			$page_size    = 20;
+
+			$page_results = Accredible_Learndash_Model_Auto_Issuance::get_paginated_results(
+				$current_page,
+				$page_size
+			);
+
+			// Capture html from display_auto_issuance_list_info
+			ob_start();
+			Accredible_Learndash_Auto_Issuance_List_Helper::display_auto_issuance_list_info( $page_results, $current_page, $page_size );
+			$auto_issuance_list_html = ob_get_clean();
+
+			wp_send_json_success( $auto_issuance_list_html );
+		}
+
+		/**
 		 * Triggers the appropriate action in Accredible_Learndash_Admin_Action_Handler
 		 */
 		public static function handle_auto_issuance_action() {
@@ -78,6 +99,35 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 			} catch ( \Exception $wp_exception ) {
 				wp_send_json_error( $wp_exception->getMessage() );
 			}
+		}
+
+		/**
+		 * Returns a resolved $_REQUEST value
+		 * 
+		 * @param string $key the key to fetch the value
+		 * @param mixed $default_value default value to return
+		 * 
+		 * @return mixed
+		 */
+		public static function get_request_value( $key, $default_value ) {
+			if ( self::has_request_value( $key ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return sanitize_text_field( wp_unslash( $_REQUEST[$key] ) );
+			} else {
+				return $default_value;
+			}
+		}
+
+		/**
+		 * Returns a boolean value if $_REQUEST value exists
+		 * 
+		 * @param string $key the key to fetch the value
+		 * 
+		 * @return boolean
+		 */
+		public static function has_request_value( $key ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return ( isset( $_REQUEST[$key] ) && ! empty( $_REQUEST[$key] ) );
 		}
 	}
 endif;

--- a/includes/ajax/class-accredible-learndash-ajax.php
+++ b/includes/ajax/class-accredible-learndash-ajax.php
@@ -103,16 +103,16 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 
 		/**
 		 * Returns a resolved $_REQUEST value
-		 * 
+		 *
 		 * @param string $key the key to fetch the value
-		 * @param mixed $default_value default value to return
-		 * 
+		 * @param mixed  $default_value default value to return
+		 *
 		 * @return mixed
 		 */
 		public static function get_request_value( $key, $default_value ) {
 			if ( self::has_request_value( $key ) ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				return sanitize_text_field( wp_unslash( $_REQUEST[$key] ) );
+				return sanitize_text_field( wp_unslash( $_REQUEST[ $key ] ) );
 			} else {
 				return $default_value;
 			}
@@ -120,14 +120,14 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 
 		/**
 		 * Returns a boolean value if $_REQUEST value exists
-		 * 
+		 *
 		 * @param string $key the key to fetch the value
-		 * 
+		 *
 		 * @return boolean
 		 */
 		public static function has_request_value( $key ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return ( isset( $_REQUEST[$key] ) && ! empty( $_REQUEST[$key] ) );
+			return ( isset( $_REQUEST[ $key ] ) && ! empty( $_REQUEST[ $key ] ) );
 		}
 	}
 endif;

--- a/includes/ajax/class-accredible-learndash-ajax.php
+++ b/includes/ajax/class-accredible-learndash-ajax.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 		/**
 		 * load auto issuances
 		 */
-		public static function load_auto_issuances() {
+		public static function load_auto_issuance_list_html() {
 			$current_page = self::get_request_value( 'page_num', 1 );
 			$page_size    = 20;
 

--- a/includes/ajax/class-accredible-learndash-ajax.php
+++ b/includes/ajax/class-accredible-learndash-ajax.php
@@ -70,7 +70,7 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 		}
 
 		/**
-		 * load auto issuances
+		 * Load auto issuances
 		 */
 		public static function load_auto_issuance_list_html() {
 			$current_page = self::get_request_value( 'page_num', 1 );
@@ -81,7 +81,7 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 				$page_size
 			);
 
-			// Capture html from display_auto_issuance_list_info
+			// Capture html from display_auto_issuance_list_info.
 			ob_start();
 			Accredible_Learndash_Auto_Issuance_List_Helper::display_auto_issuance_list_info( $page_results, $current_page, $page_size );
 			$auto_issuance_list_html = ob_get_clean();
@@ -104,30 +104,19 @@ if ( ! class_exists( 'Accredible_Learndash_Ajax' ) ) :
 		/**
 		 * Returns a resolved $_REQUEST value
 		 *
-		 * @param string $key the key to fetch the value
-		 * @param mixed  $default_value default value to return
+		 * @param string $key the key to fetch the value.
+		 * @param mixed  $default_value default value to return.
 		 *
 		 * @return mixed
 		 */
 		public static function get_request_value( $key, $default_value ) {
-			if ( self::has_request_value( $key ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_REQUEST[ $key ] ) && ! empty( $_REQUEST[ $key ] ) ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				return sanitize_text_field( wp_unslash( $_REQUEST[ $key ] ) );
 			} else {
 				return $default_value;
 			}
-		}
-
-		/**
-		 * Returns a boolean value if $_REQUEST value exists
-		 *
-		 * @param string $key the key to fetch the value
-		 *
-		 * @return boolean
-		 */
-		public static function has_request_value( $key ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return ( isset( $_REQUEST[ $key ] ) && ! empty( $_REQUEST[ $key ] ) );
 		}
 	}
 endif;

--- a/includes/class-accredible-learndash-admin.php
+++ b/includes/class-accredible-learndash-admin.php
@@ -112,6 +112,7 @@ if ( ! class_exists( 'Accredible_Learndash_Admin' ) ) :
 		public static function add_ajax_actions() {
 			add_action( 'wp_ajax_accredible_learndash_ajax_search_groups', array( 'Accredible_Learndash_Ajax', 'search_groups' ) );
 			add_action( 'wp_ajax_accredible_learndash_ajax_load_issuer_html', array( 'Accredible_Learndash_Ajax', 'load_issuer_html' ) );
+			add_action( 'wp_ajax_accredible_learndash_ajax_load_auto_issuance_list_html', array( 'Accredible_Learndash_Ajax', 'load_auto_issuance_list_html' ) );
 			add_action( 'wp_ajax_accredible_learndash_ajax_handle_auto_issuance_action', array( 'Accredible_Learndash_Ajax', 'handle_auto_issuance_action' ) );
 		}
 	}

--- a/includes/helpers/class-accredible-learndash-auto-issuance-list-helper.php
+++ b/includes/helpers/class-accredible-learndash-auto-issuance-list-helper.php
@@ -30,8 +30,8 @@ if ( ! class_exists( 'Accredible_Learndash_Auto_Issuance_List_Helper' ) ) :
 		 * Displays auto issuance list information html.
 		 *
 		 * @param mixed $page_results auto issuance list and page meta.
-		 * @param int   $current_page current page
-		 * @param int   $page_size number of results shown in page
+		 * @param int   $current_page current page.
+		 * @param int   $page_size number of results shown in page.
 		 */
 		public static function display_auto_issuance_list_info( $page_results, $current_page, $page_size ) {
 			$table_helper = new Accredible_Learndash_Admin_Table_Helper(

--- a/includes/helpers/class-accredible-learndash-auto-issuance-list-helper.php
+++ b/includes/helpers/class-accredible-learndash-auto-issuance-list-helper.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'Accredible_Learndash_Auto_Issuance_List_Helper' ) ) :
 	 */
 	class Accredible_Learndash_Auto_Issuance_List_Helper {
 		const TABLE_COLUMNS = array( 'post_id', 'accredible_group_id', 'kind', 'created_at' );
-		const ROW_ACTIONS = array(
+		const ROW_ACTIONS   = array(
 			array(
 				'action' => 'edit_auto_issuance',
 				'label'  => 'Edit',
@@ -30,8 +30,8 @@ if ( ! class_exists( 'Accredible_Learndash_Auto_Issuance_List_Helper' ) ) :
 		 * Displays auto issuance list information html.
 		 *
 		 * @param mixed $page_results auto issuance list and page meta.
-		 * @param int $current_page current page
-		 * @param int $page_size number of results shown in page
+		 * @param int   $current_page current page
+		 * @param int   $page_size number of results shown in page
 		 */
 		public static function display_auto_issuance_list_info( $page_results, $current_page, $page_size ) {
 			$table_helper = new Accredible_Learndash_Admin_Table_Helper(

--- a/includes/helpers/class-accredible-learndash-auto-issuance-list-helper.php
+++ b/includes/helpers/class-accredible-learndash-auto-issuance-list-helper.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Accredible LearnDash Add-on auto issuance list helper
+ *
+ * @package Accredible_Learndash_Add_On
+ */
+
+defined( 'ABSPATH' ) || die;
+
+require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-table-helper.php';
+
+if ( ! class_exists( 'Accredible_Learndash_Auto_Issuance_List_Helper' ) ) :
+	/**
+	 * Accredible LearnDash Add-on auto issuance list helper class
+	 */
+	class Accredible_Learndash_Auto_Issuance_List_Helper {
+		const TABLE_COLUMNS = array( 'post_id', 'accredible_group_id', 'kind', 'created_at' );
+		const ROW_ACTIONS = array(
+			array(
+				'action' => 'edit_auto_issuance',
+				'label'  => 'Edit',
+			),
+			array(
+				'action' => 'delete_auto_issuance',
+				'label'  => 'Delete',
+			),
+		);
+
+		/**
+		 * Displays auto issuance list information html.
+		 *
+		 * @param mixed $page_results auto issuance list and page meta.
+		 * @param int $current_page current page
+		 * @param int $page_size number of results shown in page
+		 */
+		public static function display_auto_issuance_list_info( $page_results, $current_page, $page_size ) {
+			$table_helper = new Accredible_Learndash_Admin_Table_Helper(
+				self::TABLE_COLUMNS,
+				$current_page,
+				$page_size,
+				self::ROW_ACTIONS
+			);
+			?>
+			<div class="accredible-table-wrapper">
+				<table class="accredible-table">
+					<thead>
+						<tr class="accredible-header-row">
+							<th></th>
+							<th>Course Name</th>
+							<th>Accredible Group</th>
+							<th>Issuance Trigger</th>
+							<th>Date Created</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php
+						echo $table_helper->build_table_rows( $page_results['results'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
+					</tbody>
+				</table>
+				<?php
+				if ( ! empty( $page_results ) && ! empty( $page_results['meta'] ) ) :
+					Accredible_Learndash_Admin_Table_Helper::build_pagination_tile( $page_results['meta'], 'auto issuances' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				endif;
+				?>
+			</div>
+			<?php
+		}
+	}
+endif;

--- a/includes/templates/admin-issuance-list.php
+++ b/includes/templates/admin-issuance-list.php
@@ -7,31 +7,13 @@
 
 defined( 'ABSPATH' ) || die;
 
-require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-table-helper.php';
+require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-auto-issuance-list-helper.php';
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance.php';
 
 $accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $accredible_learndash_page_size     = 20;
-$accredible_learndash_table_columns = array( 'post_id', 'accredible_group_id', 'kind', 'created_at' );
-$accredible_learndash_row_actions   = array(
-	array(
-		'action' => 'edit_auto_issuance',
-		'label'  => 'Edit',
-	),
-	array(
-		'action' => 'delete_auto_issuance',
-		'label'  => 'Delete',
-	),
-);
 
-$accredible_learndash_table_helper = new Accredible_Learndash_Admin_Table_Helper(
-	$accredible_learndash_table_columns,
-	$accredible_learndash_current_page,
-	$accredible_learndash_page_size,
-	$accredible_learndash_row_actions
-);
-
-$accredible_learndash_page = Accredible_Learndash_Model_Auto_Issuance::get_paginated_results(
+$accredible_learndash_page_results = Accredible_Learndash_Model_Auto_Issuance::get_paginated_results(
 	$accredible_learndash_current_page,
 	$accredible_learndash_page_size
 );
@@ -47,29 +29,10 @@ $accredible_learndash_page = Accredible_Learndash_Model_Auto_Issuance::get_pagin
 		</a>
 	</div>
 	<div class="accredible-content">
-		<div class="accredible-table-wrapper">
-			<table class="accredible-table">
-				<thead>
-					<tr class="accredible-header-row">
-						<th></th>
-						<th>Course Name</th>
-						<th>Accredible Group</th>
-						<th>Issuance Trigger</th>
-						<th>Date Created</th>
-						<th></th>
-					</tr>
-				</thead>
-				<tbody>
-					<?php
-					echo $accredible_learndash_table_helper->build_table_rows( $accredible_learndash_page['results'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					?>
-				</tbody>
-			</table>
-			<?php
-			if ( ! empty( $accredible_learndash_page ) && ! empty( $accredible_learndash_page['meta'] ) ) :
-				Accredible_Learndash_Admin_Table_Helper::build_pagination_tile( $accredible_learndash_page['meta'], 'auto issuances' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			endif;
-			?>
-		</div>
+		<?php Accredible_Learndash_Auto_Issuance_List_Helper::display_auto_issuance_list_info(
+			$accredible_learndash_page_results, 
+			$accredible_learndash_current_page,
+			$accredible_learndash_page_size
+		); ?>
 	</div>
 </div>

--- a/includes/templates/admin-issuance-list.php
+++ b/includes/templates/admin-issuance-list.php
@@ -10,9 +10,8 @@ defined( 'ABSPATH' ) || die;
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-auto-issuance-list-helper.php';
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance.php';
 
-$accredible_learndash_current_page  = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$accredible_learndash_page_size     = 20;
-
+$accredible_learndash_current_page = isset( $_GET['page_num'] ) ? sanitize_key( wp_unslash( $_GET['page_num'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$accredible_learndash_page_size    = 20;
 $accredible_learndash_page_results = Accredible_Learndash_Model_Auto_Issuance::get_paginated_results(
 	$accredible_learndash_current_page,
 	$accredible_learndash_page_size
@@ -29,10 +28,12 @@ $accredible_learndash_page_results = Accredible_Learndash_Model_Auto_Issuance::g
 		</a>
 	</div>
 	<div class="accredible-content">
-		<?php Accredible_Learndash_Auto_Issuance_List_Helper::display_auto_issuance_list_info(
-			$accredible_learndash_page_results, 
+		<?php
+		Accredible_Learndash_Auto_Issuance_List_Helper::display_auto_issuance_list_info(
+			$accredible_learndash_page_results,
 			$accredible_learndash_current_page,
 			$accredible_learndash_page_size
-		); ?>
+		);
+		?>
 	</div>
 </div>

--- a/tests/includes/test-class-accredible-learndash-admin.php
+++ b/tests/includes/test-class-accredible-learndash-admin.php
@@ -73,6 +73,13 @@ class Accredible_Learndash_Admin_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			10,
 			has_filter(
+				'wp_ajax_accredible_learndash_ajax_load_auto_issuance_list_html',
+				array( 'Accredible_Learndash_Ajax', 'load_auto_issuance_list_html' )
+			)
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
 				$activation_hook_name,
 				array( 'Accredible_Learndash_Admin_Setting', 'set_default' )
 			)


### PR DESCRIPTION
**This PR adds** 
- functionality to fetch auto-issuances using Ajax.
- `Accredible_Learndash_Auto_Issuance_List_Helper` to handle the display of auto-issuances table and pagination

**How to Test** 
- paste the code below at the end of `admin-issuance-list.php` file 
```
<button id="refetch"
		type="button"
		class="button accredible-button-primary accredible-button-small">
	Load list
</button>

<script type="text/javascript">
	jQuery(function(){
		jQuery('.accredible-content').html(''); // remove the loaded table

		// load table + pagination on button click
		jQuery('#refetch').on('click', function() {
			accredibleAjax.loadAutoIssuanceListInfo().always(function(res){
				const issuerHTML = res.data;
				jQuery('.accredible-content').html(issuerHTML);
			});
		});
	});
</script>
```