### PR TITLE
NTGR-717: Add functions to load LearnDash lessons

### DIFF
--- a/accredible-learndash-add-on.php
+++ b/accredible-learndash-add-on.php
@@ -39,7 +39,7 @@ if ( ! defined( 'ACCREDIBLE_LEARNDASH_PLUGIN_URL' ) ) {
 
 if ( is_admin() ) {
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-accredible-learndash-admin.php';
-	Accredible_Learndash_Admin::init();
+	add_action( 'plugins_loaded', array( 'Accredible_Learndash_Admin', 'init' ), 11 );
 }
 
 require_once plugin_dir_path( __FILE__ ) . '/includes/class-accredible-learndash.php';

--- a/includes/learndash/class-accredible-learndash-learndash-functions.php
+++ b/includes/learndash/class-accredible-learndash-learndash-functions.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Accredible LearnDash Add-on LearnDash functions class
+ *
+ * @package Accredible_Learndash_Add_On
+ */
+
+defined( 'ABSPATH' ) || die;
+
+if ( ! class_exists( 'Accredible_Learndash_Learndash_Functions' ) ) :
+	/**
+	 * Accredible LearnDash Add-on LearnDash functions class.
+	 */
+	class Accredible_Learndash_Learndash_Functions {
+		/**
+		 * Gets the lesson list output for a course.
+		 *
+		 * @param WP_Post|int|null $course_id The course ID or WP_Post object.
+		 * @param int|null         $user_id User ID.
+		 * @param Array            $query_args An array of query arguments to get lesson list.
+		 */
+		public function learndash_get_course_lessons_list( $course_id = null, $user_id = null, $query_args = array() ) {
+			if ( function_exists( 'learndash_get_course_lessons_list' ) ) {
+				return learndash_get_course_lessons_list( $course_id, $user_id, $query_args );
+			}
+		}
+
+		/**
+		 * Determine the type of ID being passed.
+		 *
+		 * @param WP_Post|int|null $id ID of the resource.
+		 * @param boolean          $bypass_cb If true will bypass course_builder logic.
+		 */
+		public function learndash_get_course_id( $id = null, $bypass_cb = false ) {
+			if ( function_exists( 'learndash_get_course_id' ) ) {
+				return learndash_get_course_id( $id, $bypass_cb );
+			}
+		}
+	}
+endif;

--- a/includes/learndash/class-accredible-learndash-learndash-functions.php
+++ b/includes/learndash/class-accredible-learndash-learndash-functions.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'Accredible_Learndash_Learndash_Functions' ) ) :
 		}
 
 		/**
-		 * Determine the type of ID being passed.
+		 * Gets the course ID for a resource.
 		 *
 		 * @param WP_Post|int|null $id ID of the resource.
 		 * @param boolean          $bypass_cb If true will bypass course_builder logic.

--- a/includes/learndash/class-accredible-learndash-learndash-utils.php
+++ b/includes/learndash/class-accredible-learndash-learndash-utils.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Accredible LearnDash Add-on utils class
+ *
+ * @package Accredible_Learndash_Add_On
+ */
+
+defined( 'ABSPATH' ) || die;
+
+require_once plugin_dir_path( __FILE__ ) . '/class-accredible-learndash-learndash-functions.php';
+
+if ( ! class_exists( 'Accredible_Learndash_Learndash_Utils' ) ) :
+	/**
+	 * Accredible LearnDash Add-on utils class.
+	 */
+	final class Accredible_Learndash_Learndash_Utils {
+		/**
+		 * Accredible_Learndash_Learndash_Utils constructor.
+		 *
+		 * @param Accredible_Learndash_Learndash_Functions $functions A mock instance to be passed when unit testing.
+		 */
+		public function __construct( $functions = null ) {
+			if ( null !== $functions ) {
+				$this->functions = $functions;
+			} else {
+				$this->functions = new Accredible_Learndash_Learndash_Functions();
+			}
+		}
+
+		/**
+		 * Get a list of lessons that belong to a course.
+		 *
+		 * @param int $course_id LearnDash course ID.
+		 *
+		 * @return array
+		 */
+		public function get_lesson_options( $course_id ) {
+			$options = array();
+			$lessons = $this->functions->learndash_get_course_lessons_list( $course_id );
+			if ( ! empty( $lessons ) ) {
+				foreach ( $lessons as $lesson ) {
+					$options[ $lesson['id'] ] = $lesson['post']->post_title;
+				}
+			}
+			return $options;
+		}
+
+		/**
+		 * Find a parent course with a LearnDash child post ID (Lesson, Topic, Quiz, etc).
+		 *
+		 * @param int $child_post_id Should be the ID of anything that belongs to a course.
+		 *
+		 * @return array
+		 */
+		public function get_parent_course( $child_post_id ) {
+			$course_id = $this->functions->learndash_get_course_id( $child_post_id );
+			$course    = get_post( $course_id );
+			if ( $course && 'sfwd-courses' === $course->post_type ) {
+				return $course;
+			}
+		}
+	}
+endif;

--- a/includes/learndash/class-accredible-learndash-learndash-utils.php
+++ b/includes/learndash/class-accredible-learndash-learndash-utils.php
@@ -28,6 +28,29 @@ if ( ! class_exists( 'Accredible_Learndash_Learndash_Utils' ) ) :
 		}
 
 		/**
+		 * Get available courses.
+		 *
+		 * @return array
+		 */
+		public static function get_course_options() {
+			$args    = array(
+				'post_type' => 'sfwd-courses',
+			);
+			$courses = array();
+			$posts   = get_posts( $args );
+
+			if ( ! empty( $posts ) ) {
+				foreach ( $posts as $value ) {
+					$course_id             = get_post_field( 'ID', $value );
+					$course_name           = get_the_title( $value );
+					$courses[ $course_id ] = $course_name;
+				}
+			}
+
+			return $courses;
+		}
+
+		/**
 		 * Get a list of lessons that belong to a course.
 		 *
 		 * @param int $course_id LearnDash course ID.
@@ -50,7 +73,7 @@ if ( ! class_exists( 'Accredible_Learndash_Learndash_Utils' ) ) :
 		 *
 		 * @param int $child_post_id Should be the ID of anything that belongs to a course.
 		 *
-		 * @return array
+		 * @return WP_POST
 		 */
 		public function get_parent_course( $child_post_id ) {
 			$course_id = $this->functions->learndash_get_course_id( $child_post_id );

--- a/includes/models/class-accredible-learndash-model-auto-issuance.php
+++ b/includes/models/class-accredible-learndash-model-auto-issuance.php
@@ -27,31 +27,6 @@ if ( ! class_exists( 'Accredible_Learndash_Model_Auto_Issuance' ) ) :
 		}
 
 		/**
-		 * Get available courses.
-		 *
-		 * @param string $post_type post_type to filter options.
-		 *
-		 * @return array
-		 */
-		public static function get_course_options( $post_type = 'sfwd-courses' ) {
-			$args    = array(
-				'post_type' => $post_type,
-			);
-			$courses = array();
-			$posts   = get_posts( $args );
-
-			if ( ! empty( $posts ) ) {
-				foreach ( $posts as $value ) {
-					$course_id             = get_post_field( 'ID', $value );
-					$course_name           = get_the_title( $value );
-					$courses[ $course_id ] = $course_name;
-				}
-			}
-
-			return $courses;
-		}
-
-		/**
 		 * Validate inserting or updating data.
 		 *
 		 * @throws Exception Exception containing the validation error message.

--- a/includes/templates/admin-auto-issuance-form.php
+++ b/includes/templates/admin-auto-issuance-form.php
@@ -8,9 +8,11 @@
 defined( 'ABSPATH' ) || die;
 
 require_once plugin_dir_path( __DIR__ ) . '/models/class-accredible-learndash-model-auto-issuance.php';
+require_once plugin_dir_path( __DIR__ ) . '/learndash/class-accredible-learndash-learndash-utils.php';
 require_once plugin_dir_path( __DIR__ ) . '/helpers/class-accredible-learndash-admin-form-helper.php';
 
-$accredible_learndash_courses     = Accredible_Learndash_Model_Auto_Issuance::get_course_options();
+$accredible_learndash_utils       = new Accredible_Learndash_Learndash_Utils();
+$accredible_learndash_courses     = $accredible_learndash_utils->get_course_options();
 $accredible_learndash_group       = array();
 $accredible_learndash_form_action = 'add_auto_issuance';
 $accredible_learndash_issuance    = (object) array(

--- a/tests/includes/learndash/test-class-accredible-learndash-learndash-utils.php
+++ b/tests/includes/learndash/test-class-accredible-learndash-learndash-utils.php
@@ -15,6 +15,46 @@ require_once ACCREDILBE_LEARNDASH_PLUGIN_PATH . '/includes/learndash/class-accre
  */
 class Accredible_Learndash_Learndash_Utils_Test extends WP_UnitTestCase {
 	/**
+	 * Test if it get the course options.
+	 */
+	public function test_get_course_options() {
+		$data1 = array(
+			'post_title' => 'Test Course Title 1',
+			'post_type'  => 'sfwd-courses',
+		);
+		$data2 = array(
+			'post_title' => 'Test Course Title 2',
+			'post_type'  => 'sfwd-courses',
+		);
+		$data3 = array(
+			'post_title' => 'Default post',
+		);
+		$id1   = self::factory()->post->create( $data1 );
+		$id2   = self::factory()->post->create( $data2 );
+		self::factory()->post->create( $data3 );
+
+		$expected_result = array(
+			$id1 => $data1['post_title'],
+			$id2 => $data2['post_title'],
+		);
+
+		$utils  = new Accredible_Learndash_Learndash_Utils();
+		$result = $utils->get_course_options();
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+	/**
+	 * Test if it return empty array when no courses available.
+	 */
+	public function test_get_course_options_when_not_found() {
+		$utils  = new Accredible_Learndash_Learndash_Utils();
+		$result = $utils->get_course_options();
+
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
 	 * Test if it returns a list of lessons that belong to a course.
 	 */
 	public function test_get_lesson_options() {

--- a/tests/includes/learndash/test-class-accredible-learndash-learndash-utils.php
+++ b/tests/includes/learndash/test-class-accredible-learndash-learndash-utils.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Class Accredible_Learndash_Learndash_Utils_Test
+ *
+ * @package Accredible_Learndash_Add_On
+ */
+
+defined( 'ABSPATH' ) || die;
+
+require_once ACCREDILBE_LEARNDASH_PLUGIN_PATH . '/includes/learndash/class-accredible-learndash-learndash-utils.php';
+require_once ACCREDILBE_LEARNDASH_PLUGIN_PATH . '/includes/learndash/class-accredible-learndash-learndash-functions.php';
+
+/**
+ * Unit tests for Accredible_Learndash_Learndash_Utils
+ */
+class Accredible_Learndash_Learndash_Utils_Test extends WP_UnitTestCase {
+	/**
+	 * Test if it returns a list of lessons that belong to a course.
+	 */
+	public function test_get_lesson_options() {
+		$data1 = array(
+			'post_title' => 'Test Course Title 1',
+			'post_type'  => 'sfwd-lessons',
+		);
+		$data2 = array(
+			'post_title' => 'Test Course Title 2',
+			'post_type'  => 'sfwd-lessons',
+		);
+		$id1   = self::factory()->post->create( $data1 );
+		$id2   = self::factory()->post->create( $data2 );
+
+		$mockbuiltin = $this->getMockBuilder( 'Accredible_Learndash_Learndash_Functions' )
+			->setMethods( array( 'learndash_get_course_lessons_list' ) )
+			->getMock();
+		$mockres     = array(
+			array(
+				'sno'                => 1,
+				'id'                 => $id1,
+				'post'               => get_post( $id1 ),
+				'permalink'          => 'http://127.0.0.1:8000/?p=56',
+				'class'              => '',
+				'status'             => 'notcompleted',
+				'sample'             => 'is_not_sample',
+				'sub_title'          => '',
+				'lesson_access_from' => null,
+			),
+			array(
+				'sno'                => 2,
+				'id'                 => $id2,
+				'post'               => get_post( $id2 ),
+				'permalink'          => 'http://127.0.0.1:8000/?p=11',
+				'class'              => '',
+				'status'             => 'completed',
+				'sample'             => 'is_not_sample',
+				'sub_title'          => '',
+				'lesson_access_from' => '',
+			),
+		);
+		$mockbuiltin->method( 'learndash_get_course_lessons_list' )
+			->with( $this->equalTo( 1 ) )
+			->willReturn( $mockres );
+
+		$expected = array(
+			$id1 => $data1['post_title'],
+			$id2 => $data2['post_title'],
+		);
+
+		$utils  = new Accredible_Learndash_Learndash_Utils( $mockbuiltin );
+		$result = $utils->get_lesson_options( 1 );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test if it returns a parent course.
+	 */
+	public function test_get_lesson_options_when_not_found() {
+		$mockbuiltin = $this->getMockBuilder( 'Accredible_Learndash_Learndash_Functions' )
+			->setMethods( array( 'learndash_get_course_lessons_list' ) )
+			->getMock();
+		$mockbuiltin->method( 'learndash_get_course_lessons_list' )
+			->with( $this->equalTo( 1 ) )
+			->willReturn( array() );
+
+		$utils  = new Accredible_Learndash_Learndash_Utils( $mockbuiltin );
+		$result = $utils->get_lesson_options( 1 );
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
+	 * Test if it return empty array when no lesson is found.
+	 */
+	public function test_get_parent_course() {
+		$course_data = array(
+			'post_title' => 'Test Course Title 1',
+			'post_type'  => 'sfwd-courses',
+		);
+		$course_id   = self::factory()->post->create( $course_data );
+
+		$mockbuiltin = $this->getMockBuilder( 'Accredible_Learndash_Learndash_Functions' )
+			->setMethods( array( 'learndash_get_course_id' ) )
+			->getMock();
+		$mockbuiltin->method( 'learndash_get_course_id' )
+			->with( $this->equalTo( 1 ) )
+			->willReturn( $course_id );
+
+		$expected = get_post( $course_id );
+		$utils    = new Accredible_Learndash_Learndash_Utils( $mockbuiltin );
+		$result   = $utils->get_parent_course( 1 );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test if it return null when no post is found.
+	 */
+	public function test_get_parent_course_when_not_found() {
+		$course_data = array(
+			'post_title' => 'Test Course Title 1',
+			'post_type'  => 'sfwd-courses',
+		);
+		$course_id   = self::factory()->post->create( $course_data );
+
+		$mockbuiltin = $this->getMockBuilder( 'Accredible_Learndash_Learndash_Functions' )
+			->setMethods( array( 'learndash_get_course_lessons_list' ) )
+			->getMock();
+		$mockbuiltin->method( 'learndash_get_course_lessons_list' )
+			->with( $this->equalTo( 1 ) )
+			->willReturn( 0 );
+
+		$utils  = new Accredible_Learndash_Learndash_Utils( $mockbuiltin );
+		$result = $utils->get_parent_course( 1 );
+		$this->assertEquals( null, $result );
+	}
+
+	/**
+	 * Test if it return null when the found post is not a course.
+	 */
+	public function test_get_parent_course_when_found_post_is_not_course() {
+		$data = array(
+			'post_title' => 'Test Course Title 1',
+			'post_type'  => 'sfwd-lessons',
+		);
+		$id   = self::factory()->post->create( $data );
+
+		$mockbuiltin = $this->getMockBuilder( 'Accredible_Learndash_Learndash_Functions' )
+			->setMethods( array( 'learndash_get_course_lessons_list' ) )
+			->getMock();
+		$mockbuiltin->method( 'learndash_get_course_lessons_list' )
+			->with( $this->equalTo( 1 ) )
+			->willReturn( $id );
+
+		$utils  = new Accredible_Learndash_Learndash_Utils( $mockbuiltin );
+		$result = $utils->get_parent_course( 1 );
+		$this->assertEquals( null, $result );
+	}
+}

--- a/tests/includes/models/test-class-accredible-learndash-model-auto-issuance.php
+++ b/tests/includes/models/test-class-accredible-learndash-model-auto-issuance.php
@@ -330,44 +330,6 @@ class Accredible_Learndash_Model_Auto_Issuance_Test extends Accredible_Learndash
 	}
 
 	/**
-	 * Test if it get the course options.
-	 */
-	public function test_get_course_options() {
-		$data1 = array(
-			'post_title' => 'Test Course Title 1',
-			'post_type'  => 'sfwd-courses',
-		);
-		$data2 = array(
-			'post_title' => 'Test Course Title 2',
-			'post_type'  => 'sfwd-courses',
-		);
-		$data3 = array(
-			'post_title' => 'Default post',
-		);
-		$id1   = self::factory()->post->create( $data1 );
-		$id2   = self::factory()->post->create( $data2 );
-		self::factory()->post->create( $data3 );
-
-		$expected_result = array(
-			$id1 => $data1['post_title'],
-			$id2 => $data2['post_title'],
-		);
-
-		$result = Accredible_Learndash_Model_Auto_Issuance::get_course_options();
-
-		$this->assertEquals( $expected_result, $result );
-	}
-
-	/**
-	 * Test if it return empty array when no courses available.
-	 */
-	public function test_get_course_options_when_not_found() {
-		$result = Accredible_Learndash_Model_Auto_Issuance::get_course_options();
-
-		$this->assertEquals( array(), $result );
-	}
-
-	/**
 	 * Test if it passes with valid data when creating.
 	 */
 	public function test_validate_when_creating() {


### PR DESCRIPTION
Source: https://accredible.atlassian.net/browse/NTGR-717

This PR adds a new class `Accredible_Learndash_Learndash_Utils` to load LearnDash lesson options and a LearnDash parent course, and also decouples `get_course_options` from`Accredible_Learndash_Model_Auto_Issuance` by moving the function to `Accredible_Learndash_Learndash_Utils`.