### PR TITLE
NTGR-644: Fix register_activation_hook not running issue

### DIFF
--- a/accredible-learndash-add-on.php
+++ b/accredible-learndash-add-on.php
@@ -37,6 +37,16 @@ if ( ! defined( 'ACCREDIBLE_LEARNDASH_PLUGIN_URL' ) ) {
 	define( 'ACCREDIBLE_LEARNDASH_PLUGIN_URL', $accredible_learndash_plugin_url );
 }
 
+// XXX `register_activation_hook` needs to be executed in the plugin main file.
+register_activation_hook(
+	ACCREDILBE_LEARNDASH_PLUGIN_BASENAME,
+	array( 'Accredible_Learndash_Admin_Setting', 'set_default' )
+);
+register_activation_hook(
+	ACCREDILBE_LEARNDASH_PLUGIN_BASENAME,
+	array( 'Accredible_Learndash_Admin_Database', 'setup' )
+);
+
 if ( is_admin() ) {
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-accredible-learndash-admin.php';
 	Accredible_Learndash_Admin::init();

--- a/includes/class-accredible-learndash-admin.php
+++ b/includes/class-accredible-learndash-admin.php
@@ -29,24 +29,8 @@ if ( ! class_exists( 'Accredible_Learndash_Admin' ) ) :
 		 * Accredible_Learndash_Admin constructor.
 		 */
 		public function __construct() {
-			$this->set_activation_hooks();
 			$this->set_admin_hooks();
 		}
-
-		/**
-		 * Initialize WP activation hooks.
-		 */
-		private function set_activation_hooks() {
-			register_activation_hook(
-				ACCREDILBE_LEARNDASH_PLUGIN_BASENAME,
-				array( 'Accredible_Learndash_Admin_Setting', 'set_default' )
-			);
-			register_activation_hook(
-				ACCREDILBE_LEARNDASH_PLUGIN_BASENAME,
-				array( 'Accredible_Learndash_Admin_Database', 'setup' )
-			);
-		}
-
 		/**
 		 * Initialize WP admin hooks.
 		 */

--- a/tests/includes/test-class-accredible-learndash-admin.php
+++ b/tests/includes/test-class-accredible-learndash-admin.php
@@ -80,20 +80,6 @@ class Accredible_Learndash_Admin_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			10,
 			has_filter(
-				$activation_hook_name,
-				array( 'Accredible_Learndash_Admin_Setting', 'set_default' )
-			)
-		);
-		$this->assertEquals(
-			10,
-			has_filter(
-				$activation_hook_name,
-				array( 'Accredible_Learndash_Admin_Database', 'setup' )
-			)
-		);
-		$this->assertEquals(
-			10,
-			has_filter(
 				$action_links_hook_name,
 				array( 'Accredible_Learndash_Admin_Menu', 'add_action_links' )
 			)


### PR DESCRIPTION
This PR fixes `register_activation_hook` not running in the staging environment. I couldn't find any official documentation that suggests this change but it seems like `register_activation_hook` needs to be called only in the plugin main file as mentioned in:

- https://stackoverflow.com/questions/16959216/register-activation-hook-in-construct-doesnt-work
- https://stackoverflow.com/questions/25176319/register-activation-hook-from-another-file

In fact, I confirmed the bug has been fixed with this change in the staging environment.